### PR TITLE
Add timeout if the server sends no data

### DIFF
--- a/request.go
+++ b/request.go
@@ -309,5 +309,5 @@ func Do(req Requester) (*Response, error) {
 	fmt.Fprint(conn, req.String())
 	fmt.Fprint(conn, "\r\n")
 
-	return newResponse(conn)
+	return newResponse(conn, req.GetTimeout())
 }


### PR DESCRIPTION
Sometimes servers complete the TCP handshake but never respond with any actual HTTP data. Currently rawhttp gets stuck when this happens.

This pull request adds a timeout to make sure rawhttp does not get stuck.  